### PR TITLE
Replace custom domain with Vercel default domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 技術記事要約シェアサービス今北産業のレポジトリ
 
-https://3lines.me/
+https://3lines-lemon.vercel.app/

--- a/front/src/app/summary/[id]/page.tsx
+++ b/front/src/app/summary/[id]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
                     url: data.imageUrl,
                 },
             ],
-            url: `https://3lines.me/summary/${params.id}`,
+            url: `https://3lines-lemon.vercel.app/summary/${params.id}`,
         },
     };
 }

--- a/front/src/components/button/PostToXButton.tsx
+++ b/front/src/components/button/PostToXButton.tsx
@@ -14,7 +14,7 @@ interface XPostButtonProps {
 const XPostButton = ({ text, id, className = '' }: XPostButtonProps) => {
     const handleClick = () => {
         const shareText = encodeURIComponent(text);
-        const shareUrl = encodeURIComponent(`https://3lines.me/summary/${id}`);
+        const shareUrl = encodeURIComponent(`https://3lines-lemon.vercel.app/summary/${id}`);
         const xShareUrl = `https://twitter.com/intent/tweet?text=${shareText}&url=${shareUrl}`;
         window.open(xShareUrl, '_blank', 'noopener,noreferrer');
 


### PR DESCRIPTION
## Summary
- Replace 3lines.me with Vercel default domain (3lines-lemon.vercel.app)

## Changes
- Update OGP URL in summary page metadata
- Update share URL in X post button  
- Update service URL in README

## Background
Custom domain 3lines.me will be released to reduce costs. Service will continue on Vercel's default domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)